### PR TITLE
Change the create function command to use the existing application insights and not a new one

### DIFF
--- a/Instructions/Labs/Module_12_Lab_b.md
+++ b/Instructions/Labs/Module_12_Lab_b.md
@@ -5,48 +5,46 @@ lab:
 ---
 
 # Lab: Configuring a Message-Based Integration Architecture
+
 # Student lab manual
 
 ## Lab scenario
 
 Adatum Corporation has several web applications that process files uploaded in regular intervals to their on-premises file servers. Files sizes vary, but they can reach up to 100 MB. Adatum is considering migrating the applications to Azure App Service or Azure Functions-based apps and using Azure Storage to host uploaded files. You plan to test two scenarios:
 
-  - using Azure Functions to automatically process new blobs uploaded to an Azure Storage container.
+- using Azure Functions to automatically process new blobs uploaded to an Azure Storage container.
 
   - using Event Grid to generate Azure Storage queue messages that will reference new blobs uploaded to an Azure Storage container.
 
 These scenarios are intended to address a challenge common to a messaging-based architecture, when sending, receiving, and manipulating large messages. Sending large messages to a message queue directly is not recommended as they would require more resources to be used, result in more bandwidth to be consumed, and negatively impact the processing speed, since messaging platforms are usually fine-tuned to handle high volumes of small messages. In addition, messaging platforms usually limit the maximum message size they can process.
 
-One potential solution is to store the message payload into an external service, like Azure Blob Store, Azure SQL or Azure Cosmos DB, get the reference to the stored payload and then send to the message bus only that reference. This architectural pattern is known as "claim check". The clients interested in processing that specific message can use the obtained reference to retrieve the payload, if needed. 
+One potential solution is to store the message payload into an external service, like Azure Blob Store, Azure SQL or Azure Cosmos DB, get the reference to the stored payload and then send to the message bus only that reference. This architectural pattern is known as "claim check". The clients interested in processing that specific message can use the obtained reference to retrieve the payload, if needed.
 
 On Azure this pattern can be implemented in several ways and with different technologies, but it typically it relies on events to either automate the claim check generation and to push it into the message bus to be used by clients or to trigger payload processing directly. One of the common components included in such implementations is Event Grid, which is an event routing service responsible for delivery of events within a configurable period (up to 24 hours). After that, events are either discarded or dead lettered. If archival of event contents or replayability of event stream are needed, it is possible to facilitate this requirement by setting up an Event Grid subscription to the Event Hub or a queue in Azure Storage where messages can be retained for longer periods and archival of messages is supported.
 
-In this lab, you will use Azure Storage Blob service to store files to be processed. A client just needs to drop the files to be shared into a designated Azure Blob container. In the first exercise, the files will be consumed directly by an Azure Function, leveraging its serverless nature. You will also take advantage of the Application Insights to provide instrumentation, facilitating monitoring and analyzing file processing. In the second exercise, you will use Event Grid to automatically generate a claim check message and send it to an Azure Storage queue. This allows a client application to poll the queue, get the message and then use the stored reference data to download the payload directly from Azure Blob Storage. 
+In this lab, you will use Azure Storage Blob service to store files to be processed. A client just needs to drop the files to be shared into a designated Azure Blob container. In the first exercise, the files will be consumed directly by an Azure Function, leveraging its serverless nature. You will also take advantage of the Application Insights to provide instrumentation, facilitating monitoring and analyzing file processing. In the second exercise, you will use Event Grid to automatically generate a claim check message and send it to an Azure Storage queue. This allows a client application to poll the queue, get the message and then use the stored reference data to download the payload directly from Azure Blob Storage.
 
 It is worth noting that the Azure Function in the first exercise relies on the Blob Storage trigger. You should opt for Event Grid trigger instead of the Blob storage trigger when dealing with the following requirements:
 
-  - blob-only storage accounts: blob storage accounts are supported for blob input and output bindings but not for blob triggers. Blob storage triggers require a general-purpose storage account.
+- blob-only storage accounts: blob storage accounts are supported for blob input and output bindings but not for blob triggers. Blob storage triggers require a general-purpose storage account.
 
   - high scale: high scale can be loosely defined as containers that have more than 100,000 blobs in them or storage accounts that have more than 100 blob updates per second.
 
-  - reduced latency: if your function app is on the Consumption plan, there can be up to a 10-minute delay in processing new blobs if a function app has gone idle. To avoid this latency, you can use an Event Grid trigger or switch to an App Service plan with the Always On setting enabled. 
+  - reduced latency: if your function app is on the Consumption plan, there can be up to a 10-minute delay in processing new blobs if a function app has gone idle. To avoid this latency, you can use an Event Grid trigger or switch to an App Service plan with the Always On setting enabled.
 
   - processing of blob delete events: blob delete events are not supported by blob storage triggers.
-
 
 ## Objectives
   
 After completing this lab, you will be able to:
 
--  Configure and validate an Azure Function App Storage Blob trigger
+- Configure and validate an Azure Function App Storage Blob trigger
 
--  Configure and validate an Azure Event Grid subscription-based queue messaging 
-
+- Configure and validate an Azure Event Grid subscription-based queue messaging
 
 ## Lab Environment
   
 Estimated Time: 60 minutes
-
 
 ## Lab Files
 
@@ -62,16 +60,15 @@ The main tasks for this exercise are as follows:
 
 1. Validate an Azure Function App Storage Blob trigger
 
-
 #### Task 1: Configure an Azure Function App Storage Blob trigger
 
 1. From your lab computer, start a web browser, navigate to the [Azure portal](https://portal.azure.com), and sign in by providing credentials of a user account with the Owner role in the subscription you will be using in this lab.
 
 1. In the Azure portal, open **Cloud Shell** pane by selecting on the toolbar icon directly to the right of the search textbox.
 
-1. If prompted to select either **Bash** or **PowerShell**, select **Bash**. 
+1. If prompted to select either **Bash** or **PowerShell**, select **Bash**.
 
-    >**Note**: If this is the first time you are starting **Cloud Shell** and you are presented with the **You have no storage mounted** message, select the subscription you are using in this lab, and select **Create storage**. 
+    >**Note**: If this is the first time you are starting **Cloud Shell** and you are presented with the **You have no storage mounted** message, select the subscription you are using in this lab, and select **Create storage**.
 
 1. From the Cloud Shell pane, run the following to generate a pseudo-random string of characters that will be used as a prefix for names of resources you will provision in this exercise:
 
@@ -132,7 +129,7 @@ The main tasks for this exercise are as follows:
    ```sh
    export FUNCTION_NAME="az30309f${PREFIX}"
 
-   az functionapp create --name "${FUNCTION_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" --storage-account "${STORAGE_ACCOUNT_NAME}" --consumption-plan-location "${LOCATION}" --runtime "dotnet" --functions-version 2
+   az functionapp create --name "${FUNCTION_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" --app-insights "$APPLICATION_INSIGHTS_NAME" --app-insights-key "$APPINSIGHTS_KEY" --storage-account "${STORAGE_ACCOUNT_NAME}" --consumption-plan-location "${LOCATION}" --runtime "dotnet" --functions-version 2
    ```
 
 1. From the Cloud Shell pane, run the following to configure Application Settings of the newly created function, linking it to the Application Insights and Azure Storage account:
@@ -145,19 +142,19 @@ The main tasks for this exercise are as follows:
 
 1. Switch to the Azure portal and navigate to the blade of the Azure Function app you created earlier in this task.
 
-1. On the Azure Function app blade, select **Functions** and then, select **+ Add**. 
+1. On the Azure Function app blade, select **Functions** and then, select **+ Add**.
 
 1. On the **New Function** blade, select **Azure Blob Storage trigger** template.
 
 1. On the **New Function** blade, specify the following and select **Create Function** to create a new function within the Azure function:
 
-    | Setting | Value | 
+    | Setting | Value |
     | --- | --- |
     | Name | **BlobTrigger** |
     | Path | **workitems/{name}** |
     | Storage account connection | **STORAGE_CONNECTION_STRING** |
 
-1. On the Azure Function app **BlobTrigger** function blade, select **Code + Test** and review the content of the run.csx file. 
+1. On the Azure Function app **BlobTrigger** function blade, select **Code + Test** and review the content of the run.csx file.
 
    ```csharp
    public static void Run(Stream myBlob, string name, ILogger log)
@@ -167,7 +164,6 @@ The main tasks for this exercise are as follows:
    ```
 
     > **Note**: By default, the function is configured to simply log the event corresponding to creation of a new blob. In order to carry out blob processing tasks, you would modify the content of this file.
-
 
 #### Task 2: Validate an Azure Function App Storage Blob trigger
 
@@ -199,7 +195,7 @@ The main tasks for this exercise are as follows:
 
 1. On the Azure Function app blade, select **Switch to classic experience \| Continue to classic experience**.
 
-1. On the Azure Function app blade, select **Monitor** entry. 
+1. On the Azure Function app blade, select **Monitor** entry.
 
 1. Note a single event entry representing uploading of the blob. Select the entry to view the **Invocation Details** blade.
 
@@ -209,8 +205,7 @@ The main tasks for this exercise are as follows:
 
 1. In the Application Insights portal, review the autogenerated Kusto query and its results.
 
-
-### Exercise 2: Configure and validate an Azure Event Grid subscription-based queue messaging 
+### Exercise 2: Configure and validate an Azure Event Grid subscription-based queue messaging
   
 The main tasks for this exercise are as follows:
 
@@ -219,7 +214,6 @@ The main tasks for this exercise are as follows:
 1. Validate an Azure Event Grid subscription-based queue messaging
 
 1. Remove Azure resources deployed in the lab
-
 
 #### Task 1: Configure an Azure Event Grid subscription-based queue messaging
 
@@ -237,7 +231,7 @@ The main tasks for this exercise are as follows:
    export PREFIX=$(echo `openssl rand -base64 5 | cut -c1-7 | tr '[:upper:]' '[:lower:]' | tr -cd '[[:alnum:]]._-'`)
    ```
 
-1. From the Cloud Shell pane, run the following to identify the Azure region hosting the target resource group and its existing resources: 
+1. From the Cloud Shell pane, run the following to identify the Azure region hosting the target resource group and its existing resources:
 
    ```sh
    export RESOURCE_GROUP_NAME_EXISTING='az30309a-labRG'
@@ -293,7 +287,6 @@ The main tasks for this exercise are as follows:
    az eventgrid event-subscription create --name "${QUEUE_SUBSCRIPTION_NAME}" --included-event-types 'Microsoft.Storage.BlobCreated' --endpoint "${STORAGE_ACCOUNT_ID}/queueservices/default/queues/${QUEUE_NAME}" --endpoint-type "storagequeue" --source-resource-id "${STORAGE_ACCOUNT_ID}"
    ```
 
-
 #### Task 2: Validate an Azure Event Grid subscription-based queue messaging
 
 1. From the Cloud Shell pane, run the following to upload a test blob to the Azure Storage account you created earlier in this task:
@@ -307,16 +300,16 @@ The main tasks for this exercise are as follows:
 
    az storage blob upload --file "${WORKITEM}" --container-name "${CONTAINER_NAME}" --name "${WORKITEM}" --auth-mode key --account-key "${AZURE_STORAGE_ACCESS_KEY}" --account-name "${STORAGE_ACCOUNT_NAME}"
    ```
-1. In the Azure portal, navigate to the blade displaying the Azure Storage account you created in the previous task of this exercise. 
 
-1. On the blade of the Azure Storage account, select **Queues** to display the list of its queues. 
+1. In the Azure portal, navigate to the blade displaying the Azure Storage account you created in the previous task of this exercise.
+
+1. On the blade of the Azure Storage account, select **Queues** to display the list of its queues.
 
 1. Select the entry representing the queue you created in the previous task of this exercise.
 
-1. Note that the queue contains a single message. Select its entry to display the **Message properties** blade. 
+1. Note that the queue contains a single message. Select its entry to display the **Message properties** blade.
 
 1. In the **MESSAGE BODY**, note the value of the **url** property, representing the URL of the Azure Storage blob you uploaded in the previous task.
-
 
 #### Task 3: Remove Azure resources deployed in the lab
 


### PR DESCRIPTION
# Module: 12
## Lab/Demo: 12 Implement an Application Infrastructure

Fixes # .

Changes proposed in this pull request:

- az function create add the parameters --app-insights and --app-insights-key to use the existing appinsights
- correct some markdown best practices
-