### PR TITLE
SAccountName not depend only from subscription

### DIFF
--- a/Allfiles/Labs/05/azuredeploy30305rgb.json
+++ b/Allfiles/Labs/05/azuredeploy30305rgb.json
@@ -64,7 +64,7 @@
     "lbbepoolname": "az30305b-bepool",
     "lbrule1name": "az303005b-lbruletcp80",
     "lbProbeName": "az30305b-hp",
-    "storageAccountName": "[concat('az30005b', uniqueString(subscription().subscriptionId))]",
+    "storageAccountName": "[concat('az30005b', uniqueString(subscription().subscriptionId,resourceGroup().id, deployment().name))]",
     "storageAccountType": "Standard_LRS",
     "vmExtensionName": "customScriptExtension",
     "windowsImage": {

--- a/Allfiles/Labs/05/azuredeploy30305rgc.json
+++ b/Allfiles/Labs/05/azuredeploy30305rgc.json
@@ -69,7 +69,7 @@
     "appGwFrontendPort": 80,
     "appGwBackendPort": 80,
     "appGwBePoolName": "[concat(variables('namingPrefix'), 'appGwBepool')]",
-    "storageAccountName": "[concat('az30005c', uniqueString(subscription().subscriptionId))]",
+    "storageAccountName": "[concat('az30005c', uniqueString(subscription().subscriptionId,resourceGroup().id, deployment().name))]",
     "storageAccountType": "[parameters('diskType')]",
     "vmssExtensionName": "customScriptExtension",
     "windowsImage": {


### PR DESCRIPTION
# Module: 05
## Lab/Demo: Module 05: Implement Load Balancing and Network Security

Fixes # .

Changes proposed in this pull request:
Change storageAccountName so that it does not depend only of the subscription in lab b and c
-
-
-