### PR TITLE
Added Do Not Delete Resource groups before Failover completes instruction

### DIFF
--- a/Instructions/Labs/Module_12_Lab.md
+++ b/Instructions/Labs/Module_12_Lab.md
@@ -435,7 +435,7 @@ The main tasks for this exercise are as follows:
 
 1. On the **Failover** blade, note the available options geared towards minimizing potential data loss. 
 
-1. Close the **Failover** blade.
+1. Close the **Failover** blade. Failover operation may take 10 to 15 minutes to complete. **DO NOT** delete the resource group and other resources before completion or else Failover operation will abort. You can check the status of Failover on **Site Recovery Jobs** blade.
 
 
 #### Task 5: Remove Azure resources deployed in the lab


### PR DESCRIPTION
Microsoft Learning Users have been deleting resource group as soon as they perform failover, causing the operation to fail. Added an ideal wait time

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

- Microsoft Learning Users have been deleting resource group as soon as they perform failover, causing the operation to fail. Added an ideal wait time
-
-