### PR TITLE
Update Module_06_Lab.md

### DIFF
--- a/Instructions/Labs/Module_06_Lab.md
+++ b/Instructions/Labs/Module_06_Lab.md
@@ -103,7 +103,7 @@ The main tasks for this exercise are as follows:
      -ResourceGroupName 'az30306a-labRG' `
      -TemplateFile $HOME/azuredeploy30306rga.json `
      -TemplateParameterFile $HOME/azuredeploy30306rga.parameters.json `
-     -vmSize=<vm_Size> `
+     -vmSize <vm_Size> `
      -AsJob
    ```
 


### PR DESCRIPTION
Typo in vmsize parameter.  Removed the "="

# Module: 06
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:
Remove the "=" from the parameter as it is not needed and causes and error.
-
-
-